### PR TITLE
Using Conda and Cuda-enabled environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,22 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3-miniconda/.devcontainer/base.Dockerfile
 
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
-ARG VARIANT="3.10-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-# COPY requirements.txt /tmp/pip-tmp/
-# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-#    && rm -rf /tmp/pip-tmp
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment to install a different version of Python than the default
+# RUN conda install -y python=3.6 \
+#     && pip install --no-cache-dir pipx \
+#     && pipx reinstall-all
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/add-notice.sh
+++ b/.devcontainer/add-notice.sh
@@ -1,0 +1,19 @@
+# Display a notice when not running in GitHub Codespaces
+
+cat << 'EOF' > /usr/local/etc/vscode-dev-containers/conda-notice.txt
+When using "conda" from outside of GitHub Codespaces, note the Anaconda repository
+contains restrictions on commercial use that may impact certain organizations. See
+https://aka.ms/vscode-remote/conda/miniconda
+
+EOF
+
+notice_script="$(cat << 'EOF'
+if [ -t 1 ] && [ "${IGNORE_NOTICE}" != "true" ] && [ "${TERM_PROGRAM}" = "vscode" ] && [ "${CODESPACES}" != "true" ] && [ ! -f "$HOME/.config/vscode-dev-containers/conda-notice-already-displayed" ]; then
+    cat "/usr/local/etc/vscode-dev-containers/conda-notice.txt"
+    mkdir -p "$HOME/.config/vscode-dev-containers"
+    ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/conda-notice-already-displayed") &)
+fi
+EOF
+)"
+
+echo "${notice_script}" | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,32 @@
 				"ms-toolsai.jupyter-renderers",
 				"ms-vscode.makefile-tools",
 				"ms-python.vscode-pylance"
-			]
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			}
 		}
 	},
 	"features": {
-		 "ghcr.io/devcontainers/features/nvidia-cuda:1": {}
-	}
+		"ghcr.io/devcontainers/features/nvidia-cuda:1": {}
+	},
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": {
+			"NODE_VERSION": "none"
+		}
+	},
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/noop.txt
+++ b/.devcontainer/noop.txt
@@ -1,0 +1,3 @@
+This file is copied into the container along with environment.yml* from the
+parent folder. This is done to prevent the Dockerfile COPY instruction from 
+failing if no environment.yml is found.

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,16 @@
 name: base
 channels:
   - defaults
+  - pytorch
 dependencies:
   - conda
   - python=3.9
   - numba
-  - pytorch==1.11.0
+  - pytorch:pytorch==1.11.0
   - pip
   - ipykernel
-  - cudatoolkit=11.3
+  - pytorch:cudatoolkit=11.3
   - numpy=1.21
-  - torchvision==0.12.0
-  - torchaudio==0.11.0
+  - pytorch:torchvision==0.12.0
+  - pytorch:torchaudio==0.11.0
 prefix: /opt/conda

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: base
 channels:
   - defaults
-  - pytorch
 dependencies:
   - conda
   - python=3.9

--- a/environment.yml
+++ b/environment.yml
@@ -1,17 +1,16 @@
-name: hf
-dependencies:
-  - pip
-  - python=3.9
-  - ipykernel 
-  - numpy=1.21
+name: base
+channels:
+  - defaults
   - pytorch
-  - cudatoolkit
+dependencies:
+  - conda
+  - python=3.9
   - numba
-  - pip:
-    - geopy==2.2.0
-    - pytest==7.1.3
-    - pandas==1.4.4
-    - click==8.1.3
-    - black==22.8.0
-    - pylint==2.15.0
-    - transformers
+  - pytorch==1.11.0
+  - pip
+  - ipykernel
+  - cudatoolkit=11.3
+  - numpy=1.21
+  - torchvision==0.12.0
+  - torchaudio==0.11.0
+prefix: /opt/conda

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 transformers
-torch
 click==7.1.2
 tensorflow==2.9.1
 beautifulsoup4==4.11.1
@@ -7,5 +6,5 @@ wikipedia==1.4.0
 pylint==2.15.0
 ipython==8.4.0
 gradio
-numpy==1.23.2
 sentencepiece
+# pytorch and cuda are installed/listed on environment.yml


### PR DESCRIPTION
Most of these changes come from using the Command Palette in Visual Studio Code with _Codespaces: Add development Container configuration files_ and then selecting "Miniconda and Python 3" as the option.

What _does not_ come from that is the `environment.yml` file which lists the Pytorch dependencies that come from the `pytorch` channel in Conda. When this Codespace sees an `environment.yml` file, it will copy it and install the dependencies.

Finally, because the interpreter setting is changed in `devcontainer.json`, VSCode will automatically detect the Conda environment and activate it:

```json
			"settings": {
				"python.defaultInterpreterPath": "/opt/conda/bin/python",
```